### PR TITLE
Fixed dir if it doesn't end on "/"

### DIFF
--- a/pihnn/graphics.py
+++ b/pihnn/graphics.py
@@ -7,10 +7,10 @@ import numpy as np
 import pihnn.nn as nn
 import pihnn.utils as utils
 import os, inspect
-mpl.rcParams['mathtext.fontset'] = 'stix'
-mpl.rcParams['font.family'] = 'STIXGeneral'
-mpl.use('Agg') 
 
+mpl.rcParams["mathtext.fontset"] = "stix"
+mpl.rcParams["font.family"] = "STIXGeneral"
+mpl.use("Agg")
 
 
 def get_triangulation(boundary, n_points_interior=5000, n_points_boundary=1000):
@@ -22,29 +22,37 @@ def get_triangulation(boundary, n_points_interior=5000, n_points_boundary=1000):
     :param n_points_interior: Number of grid points in the interior of the domain.
     :type n_points_interior: int
     :param n_points_exterior: Number of grid points on the boundary of the domain.
-    :type n_points_exterior: int 
+    :type n_points_exterior: int
     :returns: **tria** (:class:`matplotlib.tri.Triangulation`) - Domain triangulation/mesh.
     """
     points_B = boundary.extract_points(n_points_boundary)[0]
-    points_I_x = torch.rand(n_points_interior, device=nn.device)*(boundary.square[1]-boundary.square[0]) + boundary.square[0]
-    points_I_y = torch.rand(n_points_interior, device=nn.device)*(boundary.square[3]-boundary.square[2]) + boundary.square[2]
-    points_I = points_I_x+1j*points_I_y
-    points_I = points_I[boundary.is_inside(points_I)==1]
+    points_I_x = (
+        torch.rand(n_points_interior, device=nn.device)
+        * (boundary.square[1] - boundary.square[0])
+        + boundary.square[0]
+    )
+    points_I_y = (
+        torch.rand(n_points_interior, device=nn.device)
+        * (boundary.square[3] - boundary.square[2])
+        + boundary.square[2]
+    )
+    points_I = points_I_x + 1j * points_I_y
+    points_I = points_I[boundary.is_inside(points_I) == 1]
     mesh = torch.cat((points_B, points_I)).cpu()
 
     tria = mpl.tri.Triangulation(mesh.real, mesh.imag)
-    barycenter = mesh[tria.triangles].sum(dim=1).to(nn.device) / 3.
-    tria.set_mask((boundary.is_inside(barycenter)==0).cpu())
+    barycenter = mesh[tria.triangles].sum(dim=1).to(nn.device) / 3.0
+    tria.set_mask((boundary.is_inside(barycenter) == 0).cpu())
 
     return tria
 
 
-def single_plot(triangulation, z, levels, title=None, cmap='jet', **kwargs):
+def single_plot(triangulation, z, levels, title=None, cmap="jet", **kwargs):
     """
     Single contour plot. Used by the other functions in this module.
 
     :param triangulation: 2D mesh used for the contour plot.
-    :type triangulation: :class:`matplotlib.tri.Triangulation` 
+    :type triangulation: :class:`matplotlib.tri.Triangulation`
     :param z: Function to be plotted.
     :type z: :class:`numpy.ndarray`/:class:`torch.tensor`
     :param levels: Levels corresponding to the contour coloring.
@@ -58,15 +66,15 @@ def single_plot(triangulation, z, levels, title=None, cmap='jet', **kwargs):
 
     if isinstance(levels, int):
         z = np.array(z)
-        ticks = np.linspace(np.min(z),np.max(z),kwargs.get('nticks',8))
+        ticks = np.linspace(np.min(z), np.max(z), kwargs.get("nticks", 8))
     else:
         levels = np.array(levels)
-        ticks = np.linspace(np.min(levels),np.max(levels),kwargs.get('nticks',8))
-    plt.colorbar(ticks=ticks, format=kwargs.get('ticks_format','%.4f'))
+        ticks = np.linspace(np.min(levels), np.max(levels), kwargs.get("nticks", 8))
+    plt.colorbar(ticks=ticks, format=kwargs.get("ticks_format", "%.4f"))
     ax = plt.gca()
-    ax.set_aspect('equal', adjustable='box')
-    axis = kwargs.get('axis', [r"$x$",r"$y$"])
-    if (title is not None):
+    ax.set_aspect("equal", adjustable="box")
+    axis = kwargs.get("axis", [r"$x$", r"$y$"])
+    if title is not None:
         plt.title(title)
     plt.xlabel(axis[0])
     plt.ylabel(axis[1])
@@ -80,39 +88,48 @@ def plot_loss(loss_train, loss_test, figsize=None, format="png", dir="results/")
     :param loss_train: Training loss at each epoch.
     :type loss_train: list of float
     :param loss_train: Test loss at each epoch.
-    :type loss_train: list of float   
+    :type loss_train: list of float
     :param figsize: Size of the :class:`matplotlib.pyplot.figure`.
-    :type figsize: tuple of float 
+    :type figsize: tuple of float
     :param format: Format of the save figure.
     :type format: str
     :param dir: Directory where to save the figure.
     :type dir: str
     """
-    if (figsize is not None):
+    if figsize is not None:
         plt.figure(figsize=figsize)
     else:
         plt.figure()
-    plt.semilogy(loss_train,'r-', linewidth=0.5, label='Training')
-    plt.semilogy(loss_test,'b--', linewidth=0.5, label='Test')
+    plt.semilogy(loss_train, "r-", linewidth=0.5, label="Training")
+    plt.semilogy(loss_test, "b--", linewidth=0.5, label="Test")
     plt.legend()
-    plt.xlabel('Epoch number')
-    plt.ylabel('MSE loss')
+    plt.xlabel("Epoch number")
+    plt.ylabel("MSE loss")
     plt.tight_layout()
-    plt.savefig(dir+"loss."+format)
+    plt.savefig(dir + "loss." + format)
     plt.close()
-    print("# Saved plot of loss at "+os.path.abspath(dir+"loss."+format))
+    print("# Saved plot of loss at " + os.path.abspath(dir + "loss." + format))
 
 
-def plot_sol(triangulation, model, model_true=None, format="png", dir="results/", figsize=None, split=False, **kwargs):
+def plot_sol(
+    triangulation,
+    model,
+    model_true=None,
+    format="png",
+    dir="results/",
+    figsize=None,
+    split=False,
+    **kwargs,
+):
     """
     Plot of the solution from the training of the network. This can be graphically compared with a reference solution (either numerical or analytical).
     The function behaves differently for each problem:
-    
-    * For the Laplace and biharmonic problems, it shows the PDE solutions. 
+
+    * For the Laplace and biharmonic problems, it shows the PDE solutions.
     * For linear elasticity, it plots the stresses.
 
     :param triangulation: 2D mesh used for the contour plot.
-    :type triangulation: :class:`matplotlib.tri.Triangulation` 
+    :type triangulation: :class:`matplotlib.tri.Triangulation`
     :param model: Neural network model.
     :type model: :class:`pihnn.nn.PIHNN`/:class:`pihnn.nn.DD_PIHNN`
     :param model_true: Reference solution. It must be a scalar function for Laplace and biharmonic problems whereas it must return the 3 components of the stress tensor when solving the linear elasticity problem. Instead, leave it to None if no comparison is desired.
@@ -126,18 +143,31 @@ def plot_sol(triangulation, model, model_true=None, format="png", dir="results/"
     :param split: Whether to split the solutions into multiple files or a single picture.
     :type split: bool
     """
-    if(model.PDE in ['laplace', 'biharmonic']):
-        plot_scalar(triangulation, model, model_true, format, dir, figsize, split, **kwargs)
-    elif(model.PDE in ['km', 'km-so']):
-        plot_stresses(triangulation, model, model_true, format, dir, figsize, split, **kwargs)
+    if model.PDE in ["laplace", "biharmonic"]:
+        plot_scalar(
+            triangulation, model, model_true, format, dir, figsize, split, **kwargs
+        )
+    elif model.PDE in ["km", "km-so"]:
+        plot_stresses(
+            triangulation, model, model_true, format, dir, figsize, split, **kwargs
+        )
 
 
-def plot_scalar(triangulation, model, model_true=None, format="png", dir="results/", figsize=None, split=False, **kwargs):
+def plot_scalar(
+    triangulation,
+    model,
+    model_true=None,
+    format="png",
+    dir="results/",
+    figsize=None,
+    split=False,
+    **kwargs,
+):
     """
     Specialization of :class:`pihnn.graphics.plot_sol` for the Laplace and biharmonic problems.
 
     :param triangulation: 2D mesh used for the contour plot.
-    :type triangulation: :class:`matplotlib.tri.Triangulation` 
+    :type triangulation: :class:`matplotlib.tri.Triangulation`
     :param model: Neural network model.
     :type model: :class:`pihnn.nn.PIHNN`/:class:`pihnn.nn.DD_PIHNN`
     :param model_true: Reference solution as a scalar function (leave it to None if no comparison is desired).
@@ -147,86 +177,136 @@ def plot_scalar(triangulation, model, model_true=None, format="png", dir="result
     :param dir: Directory where to save the figure.
     :type dir: str
     :param figsize: Size of the :class:`matplotlib.pyplot.figure`. If None, no figure is created.
-    :type figsize: tuple of float 
+    :type figsize: tuple of float
     :param split: Whether to split the solutions into multiple files or a single picture.
     :type split: bool
     """
 
-    z = torch.tensor(triangulation.x + 1.j*triangulation.y).to(nn.device).requires_grad_(True)
+    z = (
+        torch.tensor(triangulation.x + 1.0j * triangulation.y)
+        .to(nn.device)
+        .requires_grad_(True)
+    )
     if isinstance(model, nn.PIHNN):
         u = model(z, real_output=True).detach().cpu()
     else:
         if len(inspect.getfullargspec(model)[0]) == 1:
             u = torch.real(model(z.detach().cpu()))
         elif len(inspect.getfullargspec(model)[0]) == 2:
-            u = torch.real(model(z.real.detach().cpu(),z.imag.detach().cpu()))
+            u = torch.real(model(z.real.detach().cpu(), z.imag.detach().cpu()))
         else:
             raise ValueError("'model' must accept 1 complex input or 2 real inputs.")
 
-    if (model_true is not None):
+    if model_true is not None:
         if isinstance(model_true, nn.PIHNN):
             u_true = model_true(z, real_output=True).detach().cpu()
         else:
             if len(inspect.getfullargspec(model_true)[0]) == 1:
                 u_true = torch.real(model_true(z.detach().cpu()))
-            elif len(inspect.getfullargspec(model_true)[0]) == 2: 
-                u_true = torch.real(model_true(z.real.detach().cpu(),z.imag.detach().cpu()))
+            elif len(inspect.getfullargspec(model_true)[0]) == 2:
+                u_true = torch.real(
+                    model_true(z.real.detach().cpu(), z.imag.detach().cpu())
+                )
             else:
-                raise ValueError("'model_true' must accept 1 complex input or 2 real inputs.")
-        levels = np.linspace(torch.min(torch.minimum(u,u_true)),torch.max(torch.maximum(u,u_true)),50)
+                raise ValueError(
+                    "'model_true' must accept 1 complex input or 2 real inputs."
+                )
+        levels = np.linspace(
+            torch.min(torch.minimum(u, u_true)), torch.max(torch.maximum(u, u_true)), 50
+        )
 
-    dir0 = dir[:len(dir)-len(dir.partition("/")[-1])]
+    dir0 = dir[: len(dir) - len(dir.partition("/")[-1])]
     if not os.path.exists(dir0):
         os.mkdir(dir0)
-        print("# Created path "+os.path.abspath(dir0))
+        print("# Created path " + os.path.abspath(dir0))
 
     if not split:
-        if (figsize is None and model_true is not None):
-            figsize = (12,4)
-        elif (figsize is None and model_true is None):
-            figsize = (4,4)        
+        if figsize is None and model_true is not None:
+            figsize = (12, 4)
+        elif figsize is None and model_true is None:
+            figsize = (4, 4)
         plt.figure(figsize=figsize)
-        if (model_true is not None):
+        if model_true is not None:
             plt.subplot(1, 3, 1)
-            single_plot(triangulation, u_true, kwargs.get('u_levels', levels), r'Exact solution', **kwargs)
+            single_plot(
+                triangulation,
+                u_true,
+                kwargs.get("u_levels", levels),
+                r"Exact solution",
+                **kwargs,
+            )
             plt.subplot(1, 3, 2)
-            single_plot(triangulation, u, kwargs.get('u_levels', levels), r'Learned solution', **kwargs)
+            single_plot(
+                triangulation,
+                u,
+                kwargs.get("u_levels", levels),
+                r"Learned solution",
+                **kwargs,
+            )
             plt.subplot(1, 3, 3)
-            single_plot(triangulation, torch.abs(u-u_true), kwargs.get('u_err_levels', 50), r'Error', **kwargs)
+            single_plot(
+                triangulation,
+                torch.abs(u - u_true),
+                kwargs.get("u_err_levels", 50),
+                r"Error",
+                **kwargs,
+            )
         else:
-            single_plot(triangulation, u, kwargs.get('u_levels', 50), r'Learned solution', **kwargs)
-        plt.savefig(dir+"solution."+format)
+            single_plot(
+                triangulation,
+                u,
+                kwargs.get("u_levels", 50),
+                r"Learned solution",
+                **kwargs,
+            )
+        plt.savefig(dir + "solution." + format)
         plt.close()
-        print("# Saved plot of solution at "+os.path.abspath(dir+"solution."+format))
+        print(
+            "# Saved plot of solution at " + os.path.abspath(dir + "solution." + format)
+        )
 
     else:
-        if(figsize is None):
-                figsize = (4,4)
+        if figsize is None:
+            figsize = (4, 4)
         if model_true is not None:
             plt.figure(1, figsize=figsize)
-            single_plot(triangulation, u_true, kwargs.get('u_levels', levels), **kwargs)
-            plt.savefig(dir+"u_exact."+format)
+            single_plot(triangulation, u_true, kwargs.get("u_levels", levels), **kwargs)
+            plt.savefig(dir + "u_exact." + format)
             plt.figure(2, figsize=figsize)
-            single_plot(triangulation, u, kwargs.get('u_levels', levels), **kwargs)
-            plt.savefig(dir+"u."+format) 
+            single_plot(triangulation, u, kwargs.get("u_levels", levels), **kwargs)
+            plt.savefig(dir + "u." + format)
             plt.figure(3, figsize=figsize)
-            single_plot(triangulation, torch.abs(u-u_true), kwargs.get('u_err_levels', 50), **kwargs)
-            plt.savefig(dir+"u_error."+format)  
-            plt.close('all')
+            single_plot(
+                triangulation,
+                torch.abs(u - u_true),
+                kwargs.get("u_err_levels", 50),
+                **kwargs,
+            )
+            plt.savefig(dir + "u_error." + format)
+            plt.close("all")
         else:
             plt.figure(figsize=figsize)
-            single_plot(triangulation, u, kwargs.get('u_levels', 50), **kwargs)
-            plt.savefig(dir+"u."+format) 
-            plt.close()          
-        print("# Saved plots of solution at "+os.path.abspath(dir))
+            single_plot(triangulation, u, kwargs.get("u_levels", 50), **kwargs)
+            plt.savefig(dir + "u." + format)
+            plt.close()
+        print("# Saved plots of solution at " + os.path.abspath(dir))
 
 
-def plot_stresses(triangulation, model, model_true=None, format="png", dir="results/", figsize=None, split=False, **kwargs):
+def plot_stresses(
+    triangulation,
+    model,
+    model_true=None,
+    format="png",
+    dir="results/",
+    figsize=None,
+    split=False,
+    **kwargs,
+):
     """
     Specialization of :class:`pihnn.graphics.plot_sol` for the linear elasticity problem.
 
     :param triangulation: 2D mesh used for the contour plot.
-    :type triangulation: :class:`matplotlib.tri.Triangulation` 
+    :type triangulation: :class:`matplotlib.tri.Triangulation`
     :param model: Neural network model.
     :type model: :class:`pihnn.nn.PIHNN`/:class:`pihnn.nn.DD_PIHNN`
     :param model_true: Reference solution. It returns the 3 components of the stress tensor (leave it to None if no comparison is desired).
@@ -236,12 +316,16 @@ def plot_stresses(triangulation, model, model_true=None, format="png", dir="resu
     :param dir: Directory where to save the figure.
     :type dir: str
     :param figsize: Size of the :class:`matplotlib.pyplot.figure`. If None, no figure is created.
-    :type figsize: tuple of float 
+    :type figsize: tuple of float
     :param split: Whether to split the solutions into multiple files or a single picture.
     :type split: bool
     """
 
-    z = torch.tensor(triangulation.x + 1.j*triangulation.y).to(nn.device).requires_grad_(True)
+    z = (
+        torch.tensor(triangulation.x + 1.0j * triangulation.y)
+        .to(nn.device)
+        .requires_grad_(True)
+    )
     if isinstance(model, nn.PIHNN):
         vars_NN = model(z, real_output=True).detach().cpu()
     else:
@@ -262,77 +346,147 @@ def plot_stresses(triangulation, model, model_true=None, format="png", dir="resu
             elif len(inspect.getfullargspec(model_true)[0]) == 2:
                 vars_true = model_true(z.real.detach().cpu(), z.imag.detach().cpu())
             else:
-                raise ValueError("'model' must accept 1 complex input or 2 real inputs.")
+                raise ValueError(
+                    "'model' must accept 1 complex input or 2 real inputs."
+                )
         nv = min(nv, vars_true.shape[0])
 
-    if nv not in [3,5]:
-        raise ValueError("Models must return either 'sigma_xx,sigma_yy,sigma_xy,u_x,u_y' or 'sigma_xx,sigma_yy,sigma_xy'.")
+    if nv not in [3, 5]:
+        raise ValueError(
+            "Models must return either 'sigma_xx,sigma_yy,sigma_xy,u_x,u_y' or 'sigma_xx,sigma_yy,sigma_xy'."
+        )
 
-    dir0 = dir[:len(dir)-len(dir.partition("/")[-1])]
+    dir0 = dir[: len(dir) - len(dir.partition("/")[-1])]
     if not os.path.exists(dir0):
         os.mkdir(dir0)
-        print("# Created path "+os.path.abspath(dir0))
+        print("# Created path " + os.path.abspath(dir0))
     names_txt = ["sxx", "syy", "sxy", "ux", "uy"]
     names_latex = ["$\sigma_{xx}$", "$\sigma_{yy}$", "$\sigma_{xy}$", "$u_x$", "$u_y$"]
 
-    if isinstance(model, nn.enriched_PIHNN) and kwargs.get('apply_crack_bounds', 0):
+    if isinstance(model, nn.enriched_PIHNN) and kwargs.get("apply_crack_bounds", 0):
         for crack in model.cracks:
             for tip in crack.tips:
-                C = torch.sqrt(torch.abs(z.detach()-tip.coords)) / torch.max(torch.sqrt(torch.abs(z.detach()-tip.coords)))
+                C = torch.sqrt(torch.abs(z.detach() - tip.coords)) / torch.max(
+                    torch.sqrt(torch.abs(z.detach() - tip.coords))
+                )
                 for i in range(3):
                     vars_NN[i] *= C.cpu()
                     if model_true is not None:
                         vars_true[i] *= C.cpu()
 
-    if(not split):
-        if(figsize is None):
-            if  model_true is not None:
-                figsize = (4*nv,4*3)
+    if not split:
+        if figsize is None:
+            if model_true is not None:
+                figsize = (4 * nv, 4 * 3)
             else:
-                figsize = (20,4)   
+                figsize = (20, 4)
         plt.figure(figsize=figsize)
         if model_true is not None:
             for i in range(nv):
-                levels = np.linspace(torch.min(torch.minimum(vars_NN[i],vars_true[i])),torch.max(torch.maximum(vars_NN[i],vars_true[i])),50)
-                plt.subplot(3,nv,i+1)
-                single_plot(triangulation, vars_true[i], kwargs.get(names_txt[i]+'_levels', levels), r'Exact '+names_latex[i], **kwargs)
-                plt.subplot(3,nv,i+nv+1)
-                single_plot(triangulation, vars_NN[i], kwargs.get(names_txt[i]+'_levels', levels), r'Learned '+names_latex[i], **kwargs)
-                plt.subplot(3,nv,i+2*nv+1)
-                single_plot(triangulation, torch.abs(vars_NN[i]-vars_true[i]), kwargs.get(names_txt[i]+'_err_levels', 50), r'Error '+names_latex[i], **kwargs)             
+                levels = np.linspace(
+                    torch.min(torch.minimum(vars_NN[i], vars_true[i])),
+                    torch.max(torch.maximum(vars_NN[i], vars_true[i])),
+                    50,
+                )
+                plt.subplot(3, nv, i + 1)
+                single_plot(
+                    triangulation,
+                    vars_true[i],
+                    kwargs.get(names_txt[i] + "_levels", levels),
+                    r"Exact " + names_latex[i],
+                    **kwargs,
+                )
+                plt.subplot(3, nv, i + nv + 1)
+                single_plot(
+                    triangulation,
+                    vars_NN[i],
+                    kwargs.get(names_txt[i] + "_levels", levels),
+                    r"Learned " + names_latex[i],
+                    **kwargs,
+                )
+                plt.subplot(3, nv, i + 2 * nv + 1)
+                single_plot(
+                    triangulation,
+                    torch.abs(vars_NN[i] - vars_true[i]),
+                    kwargs.get(names_txt[i] + "_err_levels", 50),
+                    r"Error " + names_latex[i],
+                    **kwargs,
+                )
         else:
             for i in range(nv):
-                plt.subplot(1, nv, i+1)
-                single_plot(triangulation, vars_NN[i], kwargs.get(names_txt[i]+'_levels', 50), r'Learned '+names_latex[i], **kwargs)
-        plt.savefig(dir+"solution."+format)
+                plt.subplot(1, nv, i + 1)
+                single_plot(
+                    triangulation,
+                    vars_NN[i],
+                    kwargs.get(names_txt[i] + "_levels", 50),
+                    r"Learned " + names_latex[i],
+                    **kwargs,
+                )
+        plt.savefig(dir + "solution." + format)
         plt.close()
-        print("# Saved plot of stresses "+ ("and displacements " if nv==5 else "") +"at "+os.path.abspath(dir+"solution."+format))
+        print(
+            "# Saved plot of stresses "
+            + ("and displacements " if nv == 5 else "")
+            + "at "
+            + os.path.abspath(dir + "solution." + format)
+        )
 
     else:
-        if(figsize is None):
-                figsize = (4,4)
+        if figsize is None:
+            figsize = (4, 4)
         for i in range(nv):
             if model_true is not None:
-                levels = np.linspace(torch.min(torch.minimum(vars_NN[i],vars_true[i])),torch.max(torch.maximum(vars_NN[i],vars_true[i])),50)
+                levels = np.linspace(
+                    torch.min(torch.minimum(vars_NN[i], vars_true[i])),
+                    torch.max(torch.maximum(vars_NN[i], vars_true[i])),
+                    50,
+                )
                 plt.figure(1, figsize=figsize)
-                single_plot(triangulation, vars_true[i], kwargs.get(names_txt[i]+'_levels', levels), **kwargs)
-                plt.savefig(dir+names_txt[i]+"_exact."+format)
+                single_plot(
+                    triangulation,
+                    vars_true[i],
+                    kwargs.get(names_txt[i] + "_levels", levels),
+                    **kwargs,
+                )
+                plt.savefig(dir + names_txt[i] + "_exact." + format)
                 plt.figure(2, figsize=figsize)
-                single_plot(triangulation, vars_NN[i], kwargs.get(names_txt[i]+'_levels', levels), **kwargs)
-                plt.savefig(dir+names_txt[i]+"."+format) 
+                single_plot(
+                    triangulation,
+                    vars_NN[i],
+                    kwargs.get(names_txt[i] + "_levels", levels),
+                    **kwargs,
+                )
+                plt.savefig(dir + names_txt[i] + "." + format)
                 plt.figure(3, figsize=figsize)
-                single_plot(triangulation, torch.abs(vars_NN[i]-vars_true[i]), kwargs.get(names_txt[i]+'_err_levels', 50), **kwargs)
-                plt.savefig(dir+names_txt[i]+"_error."+format)  
-                plt.close('all')
+                single_plot(
+                    triangulation,
+                    torch.abs(vars_NN[i] - vars_true[i]),
+                    kwargs.get(names_txt[i] + "_err_levels", 50),
+                    **kwargs,
+                )
+                plt.savefig(dir + names_txt[i] + "_error." + format)
+                plt.close("all")
             else:
                 plt.figure(figsize=figsize)
-                single_plot(triangulation, vars_NN[i], kwargs.get(names_txt[i]+'_levels', 50), **kwargs)
-                plt.savefig(dir+names_txt[i]+"."+format) 
-                plt.close()          
-        print("# Saved plots of stresses "+ ("and displacements " if nv==5 else "") +"at "+os.path.abspath(dir))
+                single_plot(
+                    triangulation,
+                    vars_NN[i],
+                    kwargs.get(names_txt[i] + "_levels", 50),
+                    **kwargs,
+                )
+                plt.savefig(dir + names_txt[i] + "." + format)
+                plt.close()
+        print(
+            "# Saved plots of stresses "
+            + ("and displacements " if nv == 5 else "")
+            + "at "
+            + os.path.abspath(dir)
+        )
 
 
-def plot_training_points(boundary, format="png", dir="results/", figsize=(8,8), markersize=4):
+def plot_training_points(
+    boundary, format="png", dir="results/", figsize=(8, 8), markersize=4
+):
     """
     Generates a plot of the current batch of training points with some information regarding the boundary conditions and the domain (the latter, only for DD-PIHNNs).
 
@@ -343,7 +497,7 @@ def plot_training_points(boundary, format="png", dir="results/", figsize=(8,8), 
     :param dir: Directory where to save the figure.
     :type dir: str
     :param figsize: Size of the :class:`matplotlib.pyplot.figure`. If None, no figure is created.
-    :type figsize: tuple of float 
+    :type figsize: tuple of float
     :param markersize: Size of the marker that is used to plot a point.
     :type markersize: float
     """
@@ -351,43 +505,77 @@ def plot_training_points(boundary, format="png", dir="results/", figsize=(8,8), 
     points = points.cpu().detach()
     bc_idxs = bc_idxs.cpu().detach()
 
-    plt.figure(figsize=figsize) 
+    plt.figure(figsize=figsize)
     for i in range(len(boundary.bc_names)):
-        if(points[bc_idxs==i].nelement() != 0):
-            plt.plot(points[bc_idxs==i].real, points[bc_idxs==i].imag, "x", markersize=markersize, label=boundary.bc_names[i])
+        if points[bc_idxs == i].nelement() != 0:
+            plt.plot(
+                points[bc_idxs == i].real,
+                points[bc_idxs == i].imag,
+                "x",
+                markersize=markersize,
+                label=boundary.bc_names[i],
+            )
     plt.legend()
     plt.xlabel(r"$x$")
     plt.ylabel(r"$y$")
-    plt.gca().set_aspect('equal', adjustable='box')
+    plt.gca().set_aspect("equal", adjustable="box")
 
-    dir0 = dir[:len(dir)-len(dir.partition("/")[-1])]
+    dir0 = dir[: len(dir) - len(dir.partition("/")[-1])]
     if not os.path.exists(dir0):
         os.mkdir(dir0)
-        print("# Created path "+os.path.abspath(dir0))
-    plt.savefig(dir+"points_bc."+format)
+        print("# Created path " + os.path.abspath(dir0))
+    plt.savefig(dir + "points_bc." + format)
     plt.close()
-    print("# Saved plot of training points at "+os.path.abspath(dir+"points_bc."+format))
+    print(
+        "# Saved plot of training points at "
+        + os.path.abspath(dir + "points_bc." + format)
+    )
 
     if boundary.dd_partition is not None and boundary.n_domains > 1:
         domains = boundary.dd_partition(points).cpu()
         plt.figure(figsize=figsize)
         for i in range(boundary.n_domains):
-            points_d = points[(domains[i,:]==1) & (torch.sum(domains, dim=0)==1)]
-            plt.plot(points_d.real, points_d.imag, "x", markersize=markersize, label="Domain "+str(i))
-            for j in range(i+1,boundary.n_domains):
-                points_d = points[(domains[i,:]==1) & (domains[j,:]==1)]
+            points_d = points[(domains[i, :] == 1) & (torch.sum(domains, dim=0) == 1)]
+            plt.plot(
+                points_d.real,
+                points_d.imag,
+                "x",
+                markersize=markersize,
+                label="Domain " + str(i),
+            )
+            for j in range(i + 1, boundary.n_domains):
+                points_d = points[(domains[i, :] == 1) & (domains[j, :] == 1)]
                 if points_d.nelement() != 0:
-                    plt.plot(points_d.real, points_d.imag, "x", markersize=markersize, label="Interface domains "+str(i)+","+str(j))
+                    plt.plot(
+                        points_d.real,
+                        points_d.imag,
+                        "x",
+                        markersize=markersize,
+                        label="Interface domains " + str(i) + "," + str(j),
+                    )
         plt.legend()
         plt.xlabel(r"$x$")
         plt.ylabel(r"$y$")
-        plt.gca().set_aspect('equal', adjustable='box')
-        plt.savefig(dir+"points_dd."+format)
+        plt.gca().set_aspect("equal", adjustable="box")
+        plt.savefig(dir + "points_dd." + format)
         plt.close()
-        print("# Saved plot of domain partitioning at "+os.path.abspath(dir+"points_dd."+format))
+        print(
+            "# Saved plot of domain partitioning at "
+            + os.path.abspath(dir + "points_dd." + format)
+        )
 
 
-def plot_dem(model, crack, tip, max_distance, n_points=100, figsize=None, format='png', dir='results/', markersize=2):
+def plot_dem(
+    model,
+    crack,
+    tip,
+    max_distance,
+    n_points=100,
+    figsize=None,
+    format="png",
+    dir="results/",
+    markersize=2,
+):
     """
     Calculate and plot stress intensity factors (SIFs) from displacement extrapolation method (DEM).
 
@@ -402,7 +590,7 @@ def plot_dem(model, crack, tip, max_distance, n_points=100, figsize=None, format
     :param n_points: Number of points to consider in the DEM regression.
     :type n_points: int
     :param figsize: Size of the :class:`matplotlib.pyplot.figure`.
-    :type figsize: tuple of float 
+    :type figsize: tuple of float
     :param format: Format of the saved figure.
     :type format: str
     :param dir: Directory where to save the figure.
@@ -410,66 +598,91 @@ def plot_dem(model, crack, tip, max_distance, n_points=100, figsize=None, format
     :param markersize: Size of the marker that is used to plot a point.
     :type markersize: float
 
-    :returns: 
+    :returns:
         - **sif_I_ext** (float) - Evaluation of the extrapolated :math:`K_I` stress intensity factor.
         - **sif_II_ext** (float) - Evaluation of the extrapolated :math:`K_{II}` stress intensity factor.
     """
     l = torch.linspace(0, 1, n_points)
     P = tip.P
-    z,_ = crack.map_point(l)
-    idx = torch.where(torch.abs(z-P)<max_distance)[0]
-    if torch.abs(z[0]-P) < 1e-5: # The crack tip coincides with the beginning of the crack line
+    z, _ = crack.map_point(l)
+    idx = torch.where(torch.abs(z - P) < max_distance)[0]
+    if (
+        torch.abs(z[0] - P) < 1e-5
+    ):  # The crack tip coincides with the beginning of the crack line
         a1 = 0
-        a2 = idx[-1]/n_points
-        z,n = crack.map_point(torch.linspace(a1,a2,n_points)) # First point is next to tip, last point is at max_distance
-    else: # The crack tip coincides with the end of the crack line
+        a2 = idx[-1] / n_points
+        z, n = crack.map_point(
+            torch.linspace(a1, a2, n_points)
+        )  # First point is next to tip, last point is at max_distance
+    else:  # The crack tip coincides with the end of the crack line
         a1 = 1
-        a2 = idx[0]/n_points
-        z,n = crack.map_point(torch.linspace(a1,a2,n_points)) # First point is next to tip, last point is at max_distance
-    z = z[1:] # Remove first point to avoid NaNs
+        a2 = idx[0] / n_points
+        z, n = crack.map_point(
+            torch.linspace(a1, a2, n_points)
+        )  # First point is next to tip, last point is at max_distance
+    z = z[1:]  # Remove first point to avoid NaNs
     n = n[1:]
     l = l[1:]
-    N = n_points-1
-    zz = torch.empty([2*N])*1.j
-    nn = torch.cat((n,n))
-    zz[:N] = z + 1e-6*n
-    zz[N:] = z - 1e-6*n
-    _,_,_,ux,uy = model(zz.requires_grad_(True), real_output=True)
-    un = ux*nn.real + uy*nn.imag
-    up = ux*nn.imag - uy*nn.real
+    N = n_points - 1
+    zz = torch.empty([2 * N]) * 1.0j
+    nn = torch.cat((n, n))
+    zz[:N] = z + 1e-6 * n
+    zz[N:] = z - 1e-6 * n
+    _, _, _, ux, uy = model(zz.requires_grad_(True), real_output=True)
+    un = ux * nn.real + uy * nn.imag
+    up = ux * nn.imag - uy * nn.real
 
-    sif_I = (un[:N]-un[N:]).detach() * torch.sqrt(2*torch.pi/torch.abs(P-z))*model.material['mu']/(model.material['km_gamma']+1)
-    sif_II = (up[:N]-up[N:]).detach() * torch.sqrt(2*torch.pi/torch.abs(P-z))*model.material['mu']/(model.material['km_gamma']+1)
-    slope_I = torch.median((sif_I-sif_I[-1])/l) # Average slope from linear regression
-    slope_II = torch.median((sif_II-sif_II[-1])/l)
-    sif_I_ext = slope_I + sif_I[-1] # Extrapolated SIF
+    sif_I = (
+        (un[:N] - un[N:]).detach()
+        * torch.sqrt(2 * torch.pi / torch.abs(P - z))
+        * model.material["mu"]
+        / (model.material["km_gamma"] + 1)
+    )
+    sif_II = (
+        (up[:N] - up[N:]).detach()
+        * torch.sqrt(2 * torch.pi / torch.abs(P - z))
+        * model.material["mu"]
+        / (model.material["km_gamma"] + 1)
+    )
+    slope_I = torch.median(
+        (sif_I - sif_I[-1]) / l
+    )  # Average slope from linear regression
+    slope_II = torch.median((sif_II - sif_II[-1]) / l)
+    sif_I_ext = slope_I + sif_I[-1]  # Extrapolated SIF
     sif_II_ext = slope_II + sif_II[-1]
 
-    if (figsize is not None):
+    if figsize is not None:
         plt.figure(figsize=figsize)
     else:
         plt.figure()
-    plt.plot(max_distance*l, sif_I, 'r*', label=r"$K_I$", markersize=markersize)
-    plt.plot(max_distance*l, slope_I*(1-l) + sif_I[-1], 'b-', label=r"$K_I$ from DEM")
+    plt.plot(max_distance * l, sif_I, "r*", label=r"$K_I$", markersize=markersize)
+    plt.plot(
+        max_distance * l, slope_I * (1 - l) + sif_I[-1], "b-", label=r"$K_I$ from DEM"
+    )
     plt.legend()
-    plt.xlabel('Distance from crack tip')
-    plt.ylabel(r'$K_I$')
+    plt.xlabel("Distance from crack tip")
+    plt.ylabel(r"$K_I$")
     plt.tight_layout()
-    plt.savefig(dir+"dem_i."+format)
+    plt.savefig(dir + "dem_i." + format)
     plt.close()
 
-    if (figsize is not None):
+    if figsize is not None:
         plt.figure(figsize=figsize)
     else:
         plt.figure()
-    plt.plot(max_distance*l, sif_II, 'r*', label=r"$K_{II}$", markersize=markersize)
-    plt.plot(max_distance*l, slope_II*(1-l) + sif_II[-1], 'b-', label=r"$K_{II}$ from DEM")
+    plt.plot(max_distance * l, sif_II, "r*", label=r"$K_{II}$", markersize=markersize)
+    plt.plot(
+        max_distance * l,
+        slope_II * (1 - l) + sif_II[-1],
+        "b-",
+        label=r"$K_{II}$ from DEM",
+    )
     plt.legend()
-    plt.xlabel('Distance from crack tip')
-    plt.ylabel(r'$K_{II}$')
+    plt.xlabel("Distance from crack tip")
+    plt.ylabel(r"$K_{II}$")
     plt.tight_layout()
-    plt.savefig(dir+"dem_ii."+format)
+    plt.savefig(dir + "dem_ii." + format)
     plt.close()
 
-    print("# Saved plots of DEM at "+os.path.abspath(dir))
+    print("# Saved plots of DEM at " + os.path.abspath(dir))
     return sif_I_ext, sif_II_ext

--- a/pihnn/utils.py
+++ b/pihnn/utils.py
@@ -503,7 +503,7 @@ def train(
 
     loss = np.column_stack((loss_epochs, loss_epochs_test))
     if dir[-1] != "/":
-        dir = dir.append("/")
+        dir = dir + "/"
     if not os.path.exists(dir):
         os.mkdir(dir)
         print("# Created path " + os.path.abspath(dir))

--- a/pihnn/utils.py
+++ b/pihnn/utils.py
@@ -1,4 +1,5 @@
 """Utilities for building and training PIHNNs."""
+
 import torch
 import pihnn.nn as nn
 import pihnn.bc as bc
@@ -14,96 +15,119 @@ def ordinal_number(n):
 
     :param n: Input integer.
     :type n: int
-    :returns: 
+    :returns:
         - **ord_n** (string) - Ordinal number.
     """
-    return "%d%s" % (n,"tsnrhtdd"[(n//10%10!=1)*(n%10<4)*n%10::4]) # From https://codegolf.stackexchange.com/questions/4707/outputting-ordinal-numbers-1st-2nd-3rd#answer-4712
+    return "%d%s" % (
+        n,
+        "tsnrhtdd"[(n // 10 % 10 != 1) * (n % 10 < 4) * n % 10 :: 4],
+    )  # From https://codegolf.stackexchange.com/questions/4707/outputting-ordinal-numbers-1st-2nd-3rd#answer-4712
 
 
 def get_complex_input(input_value):
     """
     | Convert the input value to the unified format (i.e., complex :class:`torch.tensor`).
-    | The library allows to define some values in multiple and flexible ways (scalars, tuples, lists, tensors). 
+    | The library allows to define some values in multiple and flexible ways (scalars, tuples, lists, tensors).
       Then, this method includes all the possible definitions and unify the type of the input value.
 
     :param input_value: Generic input value.
     :type input_value: int/float/complex/list/tuple/:class:`torch.tensor`
-    :returns: 
+    :returns:
         - **new_value** (callable) - Copy of the input value in the unified format.
     """
-    if isinstance(input_value, (int,float,complex)):
-        return torch.tensor(input_value +0j, device=nn.device)
-    elif isinstance(input_value, (list,tuple)):
+    if isinstance(input_value, (int, float, complex)):
+        return torch.tensor(input_value + 0j, device=nn.device)
+    elif isinstance(input_value, (list, tuple)):
         if len(input_value) == 1:
             return torch.tensor(input_value[0] + 0j, device=nn.device)
         if len(input_value) == 2:
-            return torch.tensor(input_value[0] + 1j*input_value[1], device=nn.device)
+            return torch.tensor(input_value[0] + 1j * input_value[1], device=nn.device)
         else:
             raise ValueError("List or tuple input must have maximum length 2.")
     elif torch.is_tensor(input_value):
         if input_value.nelement() == 1:
             return torch.tensor(input_value.item() + 0j, device=nn.device).unsqueeze(0)
         if input_value.nelement() == 2:
-            return input_value[0] + 1j*input_value[1]
+            return input_value[0] + 1j * input_value[1]
         else:
             raise ValueError("Tensor input must have maximum 2 elements.")
     else:
-        raise ValueError("Input value must be a float, complex, tuple, list or torch.tensor of length 1 or 2.")
+        raise ValueError(
+            "Input value must be a float, complex, tuple, list or torch.tensor of length 1 or 2."
+        )
 
 
 def get_complex_function(func):
     """
     | Convert the input function to the unified format (i.e., callable: complex :class:`torch.tensor` -> complex :class:`torch.tensor`).
-    | The library allows to define some functions in multiple and flexible ways (callables, constants, lists, tensors). 
-      Then, this method includes all the possible definitions and unify the type of the generic function. 
+    | The library allows to define some functions in multiple and flexible ways (callables, constants, lists, tensors).
+      Then, this method includes all the possible definitions and unify the type of the generic function.
 
     :param func: Generic input function.
     :type func: int/float/complex/list/tuple/:class:`torch.tensor`/callable
-    :returns: 
+    :returns:
         - **new_func** (callable) - Copy of the input function in the unified format.
     """
     if callable(func):
         if len(inspect.getfullargspec(func)[0]) == 1:
-            output = func(torch.tensor([0.j]))
-            if isinstance(output, (int,float,complex)):
-                new_func = lambda z: func(z) + 0*z 
+            output = func(torch.tensor([0.0j]))
+            if isinstance(output, (int, float, complex)):
+                new_func = lambda z: func(z) + 0 * z
             elif torch.is_tensor(output):
                 if output.nelement() == 1:
-                    new_func = lambda z: func(z) + 0*z
+                    new_func = lambda z: func(z) + 0 * z
                 elif output.nelement() == 2:
-                    new_func = lambda z: func(z)[0] + 1.j*func(z)[1] + 0*z
-            elif isinstance(output, (tuple,list)):
-                    new_func = lambda z: func(z)[0] + 1.j*func(z)[1] + 0*z
+                    new_func = lambda z: func(z)[0] + 1.0j * func(z)[1] + 0 * z
+            elif isinstance(output, (tuple, list)):
+                new_func = lambda z: func(z)[0] + 1.0j * func(z)[1] + 0 * z
             else:
-                raise ValueError("No suitable combination found for the output of input function.")      
+                raise ValueError(
+                    "No suitable combination found for the output of input function."
+                )
         elif len(inspect.getfullargspec(func)[0]) == 2:
-            output = func(torch.tensor([0.]),torch.tensor([0.]))
-            if isinstance(output, (int,float,complex)):
-                new_func = lambda z: func(z) + 0*z 
+            output = func(torch.tensor([0.0]), torch.tensor([0.0]))
+            if isinstance(output, (int, float, complex)):
+                new_func = lambda z: func(z) + 0 * z
             elif torch.is_tensor(output):
                 if output.nelement() == 1:
-                    new_func = lambda z: func(z.real,z.imag) + 0*z
+                    new_func = lambda z: func(z.real, z.imag) + 0 * z
                 elif output.nelement() == 2:
-                    new_func = lambda z: func(z.real,z.imag)[0] + 1.j*func(z.real,z.imag)[1] + 0*z
-            elif isinstance(output, (tuple,list)):
-                    new_func = lambda z: func(z.real,z.imag)[0] + 1.j*func(z.real,z.imag)[1] + 0*z
+                    new_func = (
+                        lambda z: func(z.real, z.imag)[0]
+                        + 1.0j * func(z.real, z.imag)[1]
+                        + 0 * z
+                    )
+            elif isinstance(output, (tuple, list)):
+                new_func = (
+                    lambda z: func(z.real, z.imag)[0]
+                    + 1.0j * func(z.real, z.imag)[1]
+                    + 0 * z
+                )
             else:
-                raise ValueError("No suitable combination found for the output of input function.")      
+                raise ValueError(
+                    "No suitable combination found for the output of input function."
+                )
         else:
-            raise ValueError("Input function must accept either 1 complex input or 2 real inputs.")
+            raise ValueError(
+                "Input function must accept either 1 complex input or 2 real inputs."
+            )
     elif isinstance(func, (int, float, complex)):
-        new_func = lambda z: func + 0*z
+        new_func = lambda z: func + 0 * z
     elif isinstance(func, (list, tuple, torch.tensor)):
         func_pt = torch.tensor(func)
         if func_pt.nelement() == 1:
             func_pt = func_pt + 0j
         elif func_pt.nelement() == 2:
-            func_pt = func_pt[0] + 1j*func_pt[1]
+            func_pt = func_pt[0] + 1j * func_pt[1]
         else:
-            raise ValueError("List/tuple/tensor input cannot have more than 2 dimensions.")
-        new_func = lambda z: func_pt + 0*z
+            raise ValueError(
+                "List/tuple/tensor input cannot have more than 2 dimensions."
+            )
+        new_func = lambda z: func_pt + 0 * z
     else:
-        raise ValueError("Input function must be a callable, a scalar, or a pair of values.")
+        raise ValueError(
+            "Input function must be a callable, a scalar, or a pair of values."
+        )
     return new_func
 
 
@@ -118,10 +142,10 @@ def MSE(value, true_value=None):
     :returns: **mse** (float) - MSE error.
     """
     if value.nelement() == 0:
-        return 0.
+        return 0.0
     if true_value is None:
         true_value = torch.zeros_like(value)
-    return torch.nn.MSELoss(reduction='sum')(value, true_value)
+    return torch.nn.MSELoss(reduction="sum")(value, true_value)
 
 
 def PIHNNloss(boundary, model, t):
@@ -136,17 +160,19 @@ def PIHNNloss(boundary, model, t):
     :type t: str
     :returns: **loss** (float) - Computed loss.
     """
-    if(model.PDE == 'laplace' or model.PDE == 'biharmonic'):
+    if model.PDE == "laplace" or model.PDE == "biharmonic":
         return scalar_loss(boundary, model, t)
-    elif(model.PDE == 'km' or model.PDE == 'km-so'):
+    elif model.PDE == "km" or model.PDE == "km-so":
         return km_loss(boundary, model, t)
     else:
-        raise ValueError("'model.PDE' must be either 'laplace', 'biharmonic', 'km' or 'km-so'.")
- 
+        raise ValueError(
+            "'model.PDE' must be either 'laplace', 'biharmonic', 'km' or 'km-so'."
+        )
+
 
 def scalar_loss(boundary, model, t):
     """
-    Called by :func:`pihnn.utils.PIHNNloss` if one aims to solve the Laplace or biharmonic problem. 
+    Called by :func:`pihnn.utils.PIHNNloss` if one aims to solve the Laplace or biharmonic problem.
 
     :param boundary: Domain boundary, needed to extract training and test points.
     :type boundary: :class:`pihnn.geometries.boundary`
@@ -161,27 +187,31 @@ def scalar_loss(boundary, model, t):
     else:
         z, normals, bc_idxs, bc_values = boundary(t)
 
-    if model.PDE in ['laplace','biharmonic']:
+    if model.PDE in ["laplace", "biharmonic"]:
         u = model(z.requires_grad_(True), real_output=True)
     else:
-        raise ValueError("'model.PDE' must be 'laplace' or 'biharmonic' for this type of loss.")
+        raise ValueError(
+            "'model.PDE' must be 'laplace' or 'biharmonic' for this type of loss."
+        )
 
     if isinstance(model, nn.DD_PIHNN):
-        u[twins[0],twins[2]] -= u[twins[1],twins[3]]
-        u[twins[1],twins[3]] = 0
+        u[twins[0], twins[2]] -= u[twins[1], twins[3]]
+        u[twins[1], twins[3]] = 0
         u[mask] = 0
-    
-    L = 0.
-    for j,bc_type in enumerate(boundary.bc_types):
-        L += bc_type.scaling_coeff*MSE(bc_type(z, u, normals, bc_values)[bc_idxs==j])
+
+    L = 0.0
+    for j, bc_type in enumerate(boundary.bc_types):
+        L += bc_type.scaling_coeff * MSE(
+            bc_type(z, u, normals, bc_values)[bc_idxs == j]
+        )
     bc.reset_variables()
     return L / z.nelement()
 
 
 def km_loss(boundary, model, t):
     """
-    Called by :func:`pihnn.utils.PIHNNloss` if one aims to solve the linear elasticity problem 
-    through the Kolosov-Muskhelishvili representation. 
+    Called by :func:`pihnn.utils.PIHNNloss` if one aims to solve the linear elasticity problem
+    through the Kolosov-Muskhelishvili representation.
 
     :param boundary: Domain boundary, needed to extract training and test points.
     :type boundary: :class:`pihnn.geometries.boundary`
@@ -196,19 +226,23 @@ def km_loss(boundary, model, t):
         z, normals, bc_idxs, bc_values, mask, twins = boundary(t, dd=True)
     else:
         z, normals, bc_idxs, bc_values = boundary(t)
-    
+
     vars = model(z.requires_grad_(True), real_output=True)
 
     if isinstance(model, nn.DD_PIHNN):
-        vars[:,twins[0],twins[2]] -= vars[:,twins[1],twins[3]]
-        vars[:,twins[1],twins[3]] = 0
-        vars[:,mask] = 0
+        vars[:, twins[0], twins[2]] -= vars[:, twins[1], twins[3]]
+        vars[:, twins[1], twins[3]] = 0
+        vars[:, mask] = 0
 
     sig_xx, sig_yy, sig_xy, u_x, u_y = vars
 
-    L = 0.
-    for j,bc_type in enumerate(boundary.bc_types):
-        L += MSE(bc_type(z, sig_xx, sig_yy, sig_xy, u_x, u_y, normals, bc_values)[bc_idxs==j])
+    L = 0.0
+    for j, bc_type in enumerate(boundary.bc_types):
+        L += MSE(
+            bc_type(z, sig_xx, sig_yy, sig_xy, u_x, u_y, normals, bc_values)[
+                bc_idxs == j
+            ]
+        )
     bc.reset_variables()
     return L / z.nelement()
 
@@ -221,31 +255,33 @@ def rotate_stresses(vars, angle):
     :type vars: :class:`torch.tensor`
     :param angle: Angle corresponding to the rotation of the original system of coordinates.
     :type angle: float
-    :returns: 
-        - **vars_roto** (:class:`torch.tensor`) - Variables evaluated in the rotated system of coordinates.  
+    :returns:
+        - **vars_roto** (:class:`torch.tensor`) - Variables evaluated in the rotated system of coordinates.
     """
     c = np.cos(angle)
     s = np.sin(angle)
     vars_roto = torch.zeros_like(vars)
 
-    vars_roto[0] = vars[0]*c*c + vars[1]*s*s + 2*vars[2]*c*s
-    vars_roto[1] = vars[0]*s*s + vars[1]*c*c - 2*vars[2]*c*s
-    vars_roto[2] = (vars[1]-vars[0])*c*s + vars[2]*(c*c-s*s)
+    vars_roto[0] = vars[0] * c * c + vars[1] * s * s + 2 * vars[2] * c * s
+    vars_roto[1] = vars[0] * s * s + vars[1] * c * c - 2 * vars[2] * c * s
+    vars_roto[2] = (vars[1] - vars[0]) * c * s + vars[2] * (c * c - s * s)
 
-    if vars.shape[0] == 5: # I.e., also displacements have to be rotated
-        vars_roto[3] = -vars[3]*c + vars[4]*s
-        vars_roto[4] =  vars[3]*s + vars[4]*c
+    if vars.shape[0] == 5:  # I.e., also displacements have to be rotated
+        vars_roto[3] = -vars[3] * c + vars[4] * s
+        vars_roto[4] = vars[3] * s + vars[4] * c
 
     return vars_roto
 
 
-def compute_J_integral(model, tip, radius=1., integration_points=1000, crack_curve=None):
+def compute_J_integral(
+    model, tip, radius=1.0, integration_points=1000, crack_curve=None
+):
     """
     Compute the J-integral.
-    
+
     .. math::
         J = \oint_{\gamma} \left(w n_x - (\sigma \cdot n)\cdot\\frac{\partial u}{\partial x}\\right) d\gamma,
-    
+
     where :math:`\gamma` is a closed curve around a crack tip and :math:`w=\\frac{1}{2}\sigma:\\varepsilon`.
     In particular, a first-order discretization is used and :math:`\gamma` is taken as a circle around the crack tip plus, if required, the crack faces.
 
@@ -259,57 +295,68 @@ def compute_J_integral(model, tip, radius=1., integration_points=1000, crack_cur
     :type integration_points: int
     :param crack_curve: Curve associated to the crack tip, for the evaluation of the I-integral on the crack faces, if needed.
     :type crack_curve: :class:`pihnn.geometries.curve`
-    :returns: 
+    :returns:
         - **J** (float) - Evaluation of the J-integral.
     """
 
     N_c = integration_points
     P = tip.coords
-    z = P + radius*torch.exp(1j*torch.linspace(-np.pi+1e-8,torch.pi+1e-8,N_c+1,device=nn.device)[:-1]).requires_grad_(True)
-    ds = 2*np.pi*radius/N_c # Differential for integration
-    n = (z-tip.coords)/radius # Normal vector
+    z = P + radius * torch.exp(
+        1j
+        * torch.linspace(-np.pi + 1e-8, torch.pi + 1e-8, N_c + 1, device=nn.device)[:-1]
+    ).requires_grad_(True)
+    ds = 2 * np.pi * radius / N_c  # Differential for integration
+    n = (z - tip.coords) / radius  # Normal vector
 
     if crack_curve is not None:
-        z1, n1 = crack_curve.map_point(torch.linspace(0.1/N_c,1-0.1/N_c,N_c,device=nn.device))
-        n1 = n1[torch.abs(z1-P)<=radius]
-        z1 = z1[torch.abs(z1-P)<=radius]
+        z1, n1 = crack_curve.map_point(
+            torch.linspace(0.1 / N_c, 1 - 0.1 / N_c, N_c, device=nn.device)
+        )
+        n1 = n1[torch.abs(z1 - P) <= radius]
+        z1 = z1[torch.abs(z1 - P) <= radius]
         z2 = z1
-        z1 = z1-1e-9*n1
-        z2 = z2+1e-9*n1
-        z = torch.cat((z,z1,z2)).requires_grad_(True)
-        n = torch.cat((n,n1,-n1))
-        ds = torch.abs(z[1:]-z[:-1])
-        ds[N_c-1] = 0 # Remove possible discontinuities between z,z1,z2
-        ds[N_c-1+int(z1.shape[0])] = 0
+        z1 = z1 - 1e-9 * n1
+        z2 = z2 + 1e-9 * n1
+        z = torch.cat((z, z1, z2)).requires_grad_(True)
+        n = torch.cat((n, n1, -n1))
+        ds = torch.abs(z[1:] - z[:-1])
+        ds[N_c - 1] = 0  # Remove possible discontinuities between z,z1,z2
+        ds[N_c - 1 + int(z1.shape[0])] = 0
         z = z[:-1]
         n = n[:-1]
 
     # Second part: computation of J-integral
-    sxx,syy,sxy,_,uy = model(z, real_output=True, force_williams=True)
+    sxx, syy, sxy, _, uy = model(z, real_output=True, force_williams=True)
 
-    C1 = (1-model.material["poisson"]**2)/model.material["young"]
-    C2 = -model.material["poisson"]*(1+model.material["poisson"])/model.material["young"]
+    C1 = (1 - model.material["poisson"] ** 2) / model.material["young"]
+    C2 = (
+        -model.material["poisson"]
+        * (1 + model.material["poisson"])
+        / model.material["young"]
+    )
 
-    exx = C1*sxx + C2*syy
-    eyy = C1*syy + C2*sxx
-    exy = sxy/2/model.material["mu"]
+    exx = C1 * sxx + C2 * syy
+    eyy = C1 * syy + C2 * sxx
+    exy = sxy / 2 / model.material["mu"]
 
-    ux_x = exx # All derivatives of u can be obtained from the strain tensor except the anti-symmetric part
+    ux_x = exx  # All derivatives of u can be obtained from the strain tensor except the anti-symmetric part
     uy_y = eyy
-    uy_x = 2*torch.real(nn.derivative(uy,z))
-    ux_y = 2*exy-uy_x
+    uy_x = 2 * torch.real(nn.derivative(uy, z))
+    ux_y = 2 * exy - uy_x
 
-    w = 0.5*(sxx*exx + syy*eyy + 2*sxy*exy) # Strain energy density
-    sn = (sxx*n.real + sxy*n.imag) + 1j*(sxy*n.real + syy*n.imag) # sigma \cdot n
+    w = 0.5 * (sxx * exx + syy * eyy + 2 * sxy * exy)  # Strain energy density
+    sn = (sxx * n.real + sxy * n.imag) + 1j * (
+        sxy * n.real + syy * n.imag
+    )  # sigma \cdot n
 
-    norm_t = n.real*tip.norm.real + n.imag*tip.norm.imag
-    ux_t = ux_x*tip.norm.real + ux_y*tip.norm.imag
-    uy_t = uy_x*tip.norm.real + uy_y*tip.norm.imag
-    J = torch.sum(w*norm_t*ds) - torch.sum((sn.real*ux_t+sn.imag*uy_t)*ds)
+    norm_t = n.real * tip.norm.real + n.imag * tip.norm.imag
+    ux_t = ux_x * tip.norm.real + ux_y * tip.norm.imag
+    uy_t = uy_x * tip.norm.real + uy_y * tip.norm.imag
+    J = torch.sum(w * norm_t * ds) - torch.sum((sn.real * ux_t + sn.imag * uy_t) * ds)
     return J
 
 
-def yau_wang_method(model, tip, radius=1., integration_points=1000, crack_curve=None):
+def yau_wang_method(model, tip, radius=1.0, integration_points=1000, crack_curve=None):
     """
     Implementation of the method from `Yau et al. [1980] <https://doi.org/10.1115/1.3153665>`_ to evaluate the
     stress intensity factors (SIFs) in mixed mode I-II from the J-integral.
@@ -323,51 +370,70 @@ def yau_wang_method(model, tip, radius=1., integration_points=1000, crack_curve=
     :param radius: Radius of the circumference where the J-integrals are computed.
     :type radius: float
     :param integration_points: Number of integration points on the circumference.
-    :type integration_points: int 
+    :type integration_points: int
     :param crack_curve: Curve associated to the crack tip, for the evaluation of the I-integral on the crack faces, if needed.
     :type crack_curve: :class:`pihnn.geometries.curve`
-    :returns: 
+    :returns:
         - **K_I** (float) - :math:`K_I` stress intensity factor.
         - **K_II** (float) - :math:`K_{II}` stress intensity factor.
     """
-    C1 = (1-model.material["poisson"]**2)/model.material["young"]
+    C1 = (1 - model.material["poisson"] ** 2) / model.material["young"]
 
     net_sif = model.sif
-    if torch.norm(net_sif)>1e-5 and model.enrichment=='rice':
-        warnings.warn("Rice-enriched network has non-zero Williams SIFs. Are you sure this is correct?")
+    if torch.norm(net_sif) > 1e-5 and model.enrichment == "rice":
+        warnings.warn(
+            "Rice-enriched network has non-zero Williams SIFs. Are you sure this is correct?"
+        )
 
     aux_sif = torch.zeros_like(net_sif)
     j = 0
     for crack in model.cracks:
         for t in crack.tips:
-            if torch.abs(t.coords-tip.coords)<1e-5:
+            if torch.abs(t.coords - tip.coords) < 1e-5:
                 idx = j
-            j+=1
+            j += 1
 
     # NN J integral
     J = compute_J_integral(model, tip, radius, integration_points, crack_curve)
     J_aux = C1
 
     # First superposed J integral
-    aux_sif[idx] = 1.
-    model.sif = torch.nn.Parameter(net_sif + aux_sif) if model.enrichment=="williams" else aux_sif
+    aux_sif[idx] = 1.0
+    model.sif = (
+        torch.nn.Parameter(net_sif + aux_sif)
+        if model.enrichment == "williams"
+        else aux_sif
+    )
     J_tot = compute_J_integral(model, tip, radius, integration_points, crack_curve)
-    I_I = J_tot-J-J_aux
+    I_I = J_tot - J - J_aux
 
-    #Second superposed J integral
-    aux_sif[idx] = 1.j
-    model.sif = torch.nn.Parameter(net_sif + aux_sif) if model.enrichment=="williams" else aux_sif
+    # Second superposed J integral
+    aux_sif[idx] = 1.0j
+    model.sif = (
+        torch.nn.Parameter(net_sif + aux_sif)
+        if model.enrichment == "williams"
+        else aux_sif
+    )
     J_tot = compute_J_integral(model, tip, radius, integration_points, crack_curve)
-    I_II = J_tot-J-J_aux
+    I_II = J_tot - J - J_aux
 
-    model.sif = net_sif # Restore initial parameters
+    model.sif = net_sif  # Restore initial parameters
 
     K_I = 0.5 * I_I / C1
     K_II = 0.5 * I_II / C1
     return K_I, K_II
 
 
-def train(boundary, model, n_epochs, learn_rate=1e-3, scheduler_apply=[], scheduler_gamma=0.5, dir="results/", apply_adaptive_sampling=0):
+def train(
+    boundary,
+    model,
+    n_epochs,
+    learn_rate=1e-3,
+    scheduler_apply=[],
+    scheduler_gamma=0.5,
+    dir="results/",
+    apply_adaptive_sampling=0,
+):
     """
     Performs the training of the neural network.
 
@@ -387,22 +453,30 @@ def train(boundary, model, n_epochs, learn_rate=1e-3, scheduler_apply=[], schedu
     :type dir: str
     :param apply_adaptive_sampling: At which epoch to apply the RAD adaptive sampling (:func:`pihnn.utils.RAD_sampling`). Leave it to 0 for no adaptive sampling.
     :type apply_adaptive_sampling: int
-    :returns: 
+    :returns:
         - **loss_epochs** (list of float) - List containing the training loss at each epoch.
         - **loss_epochs_test** (list of float) - List containing the test loss at each epoch.
-     """
+    """
     optimizer = torch.optim.Adam(model.parameters(), lr=learn_rate)
     scheduler = torch.optim.lr_scheduler.ExponentialLR(optimizer, gamma=scheduler_gamma)
     loss_epochs = []
     loss_epochs_test = []
 
     for bc_type in boundary.bc_types:
-        if model.PDE in ['laplace','biharmonic'] and not issubclass(bc_type.__class__,bc.scalar_bc):
-            raise ValueError("'laplace' and 'biharmonic' problems require boundary conditions derived from 'scalar_bc'.")
-        elif model.PDE in ['km','km-so'] and not issubclass(bc_type.__class__,bc.linear_elasticity_bc):
-            raise ValueError("Linear elasticity problems require boundary conditions derived from 'linear_elasticity_bc'.")
+        if model.PDE in ["laplace", "biharmonic"] and not issubclass(
+            bc_type.__class__, bc.scalar_bc
+        ):
+            raise ValueError(
+                "'laplace' and 'biharmonic' problems require boundary conditions derived from 'scalar_bc'."
+            )
+        elif model.PDE in ["km", "km-so"] and not issubclass(
+            bc_type.__class__, bc.linear_elasticity_bc
+        ):
+            raise ValueError(
+                "Linear elasticity problems require boundary conditions derived from 'linear_elasticity_bc'."
+            )
 
-    for epoch_id in (pbar:=tqdm(range(n_epochs))):
+    for epoch_id in (pbar := tqdm(range(n_epochs))):
 
         if epoch_id == apply_adaptive_sampling and epoch_id != 0:
             RAD_sampling(boundary, model)
@@ -417,9 +491,14 @@ def train(boundary, model, n_epochs, learn_rate=1e-3, scheduler_apply=[], schedu
         loss_epochs_test.append(loss_test.cpu().data)
 
         with torch.autograd.no_grad():
-            if (epoch_id % 10 == 0):
-                pbar.set_postfix_str("training loss: "+"%.2E" % loss_epochs[-1]+", test loss: "+"%.2E" % loss_epochs_test[-1])
-            if (epoch_id in scheduler_apply):
+            if epoch_id % 10 == 0:
+                pbar.set_postfix_str(
+                    "training loss: "
+                    + "%.2E" % loss_epochs[-1]
+                    + ", test loss: "
+                    + "%.2E" % loss_epochs_test[-1]
+                )
+            if epoch_id in scheduler_apply:
                 scheduler.step()
 
     loss = np.column_stack((loss_epochs, loss_epochs_test))
@@ -427,11 +506,11 @@ def train(boundary, model, n_epochs, learn_rate=1e-3, scheduler_apply=[], schedu
         dir = dir.append("/")
     if not os.path.exists(dir):
         os.mkdir(dir)
-        print("# Created path "+os.path.abspath(dir))
-    np.savetxt(dir+"loss.dat", loss)
-    print("# Saved loss at "+os.path.abspath(dir+"loss.dat"))
-    torch.save(model.state_dict(), dir+"model.dict")
-    print("# Saved neural network model at "+os.path.abspath(dir+"model.dict"))
+        print("# Created path " + os.path.abspath(dir))
+    np.savetxt(dir + "loss.dat", loss)
+    print("# Saved loss at " + os.path.abspath(dir + "loss.dat"))
+    torch.save(model.state_dict(), dir + "model.dict")
+    print("# Saved neural network model at " + os.path.abspath(dir + "model.dict"))
 
     return loss_epochs, loss_epochs_test
 
@@ -449,25 +528,45 @@ def RAD_sampling(boundary, model, fine_grid=10000):
     """
     z, normals, bc_idxs, bc_values = boundary.extract_points(fine_grid)
     epsilon = torch.zeros_like(z, dtype=torch.float64)
-    
+
     idx = torch.tensor([], dtype=bc_idxs.dtype)
 
-    for j,bc_type in enumerate(boundary.bc_types):
-        if(model.PDE == 'laplace' or model.PDE == 'biharmonic'):
-            u = model(z[bc_idxs==j].requires_grad_(True), real_output=True)
-            epsilon = bc_type(z[bc_idxs==j], u, normals[bc_idxs==j], bc_values[bc_idxs==j])
+    for j, bc_type in enumerate(boundary.bc_types):
+        if model.PDE == "laplace" or model.PDE == "biharmonic":
+            u = model(z[bc_idxs == j].requires_grad_(True), real_output=True)
+            epsilon = bc_type(
+                z[bc_idxs == j], u, normals[bc_idxs == j], bc_values[bc_idxs == j]
+            )
         else:
-            sig_xx, sig_yy, sig_xy, u_x, u_y = model(z[bc_idxs==j].requires_grad_(True), real_output=True)
-            epsilon = bc_type(z[bc_idxs==j], sig_xx, sig_yy, sig_xy, u_x, u_y, normals[bc_idxs==j], bc_values[bc_idxs==j])
+            sig_xx, sig_yy, sig_xy, u_x, u_y = model(
+                z[bc_idxs == j].requires_grad_(True), real_output=True
+            )
+            epsilon = bc_type(
+                z[bc_idxs == j],
+                sig_xx,
+                sig_yy,
+                sig_xy,
+                u_x,
+                u_y,
+                normals[bc_idxs == j],
+                bc_values[bc_idxs == j],
+            )
 
-        epsilon = epsilon/torch.mean(epsilon) + 1
+        epsilon = epsilon / torch.mean(epsilon) + 1
         epsilon /= torch.sum(epsilon)
 
-        num_samples = int(boundary.np_train*torch.sum(bc_idxs==j)/torch.sum(bc_idxs>=0))
+        num_samples = int(
+            boundary.np_train * torch.sum(bc_idxs == j) / torch.sum(bc_idxs >= 0)
+        )
         idx_bc = epsilon.multinomial(num_samples=num_samples)
-        idx = torch.cat([idx,torch.where(bc_idxs==j)[0][idx_bc]])
+        idx = torch.cat([idx, torch.where(bc_idxs == j)[0][idx_bc]])
 
-    boundary.points_train, boundary.normals_train, boundary.bc_idxs_train, boundary.bc_values_train = z[idx], normals[idx], bc_idxs[idx], bc_values[idx]
+    (
+        boundary.points_train,
+        boundary.normals_train,
+        boundary.bc_idxs_train,
+        boundary.bc_values_train,
+    ) = (z[idx], normals[idx], bc_idxs[idx], bc_values[idx])
 
 
 def compute_Lp_error(triangulation, model, model_true, p=2):
@@ -475,13 +574,13 @@ def compute_Lp_error(triangulation, model, model_true, p=2):
     Compute and print to screen the approximated relative :math:`L^p` error between a model and a reference solution. I.e.,
 
     .. math::
-        \\frac{\|u_{NN}-u\|_{L^p(\Omega)}}{\|u\|_{L^p(\Omega)}} = \left(\\frac{\int_{\Omega} |u_{NN}-u|^p}{\int_{\Omega} |u|^p} \\right)^{1/p} 
+        \\frac{\|u_{NN}-u\|_{L^p(\Omega)}}{\|u\|_{L^p(\Omega)}} = \left(\\frac{\int_{\Omega} |u_{NN}-u|^p}{\int_{\Omega} |u|^p} \\right)^{1/p}
         \\approx \left(\\frac{\sum_{(x,y)\in \mathcal{T}} |u_{NN}(x,y)-u(x,y)|^p}{\sum_{(x,y)\in \mathcal{T}} |u(x,y)|^p} \\right)^{1/p},
 
-    where :math:`u` denotes any of the variables of interest and :math:`\mathcal{T}` is the set of points in the triangulation. 
+    where :math:`u` denotes any of the variables of interest and :math:`\mathcal{T}` is the set of points in the triangulation.
 
     :param triangulation: 2D mesh used for evaluating the model.
-    :type triangulation: :class:`matplotlib.tri.Triangulation` 
+    :type triangulation: :class:`matplotlib.tri.Triangulation`
     :param model: Neural network model.
     :type model: :class:`pihnn.nn.PIHNN`/:class:`pihnn.nn.DD_PIHNN`
     :param model_true: Reference solution. It must be a scalar function for Laplace and biharmonic problems whereas it must return the 3 components of the stress tensor when solving the linear elasticity problem.
@@ -489,34 +588,56 @@ def compute_Lp_error(triangulation, model, model_true, p=2):
     :param p: Exponent for the :math:`L^p` error.
     :type p: int
     :returns: **errors** (list of float) - Approximated :math:`L^p` error for each variable of interest.
-     """
+    """
 
-    z = torch.tensor(triangulation.x + 1.j*triangulation.y).to(nn.device).requires_grad_(True)
+    z = (
+        torch.tensor(triangulation.x + 1.0j * triangulation.y)
+        .to(nn.device)
+        .requires_grad_(True)
+    )
 
     if isinstance(model, nn.PIHNN):
         vars = model(z, real_output=True).detach().cpu()
     else:
-        if len(inspect.getfullargspec(model)[0]) == 1: # Check if it's a scalar complex function
+        if (
+            len(inspect.getfullargspec(model)[0]) == 1
+        ):  # Check if it's a scalar complex function
             vars = model(z.detach().cpu())
-        elif len(inspect.getfullargspec(model)[0]) == 2: # Check if it's a function with two scalar inputs
+        elif (
+            len(inspect.getfullargspec(model)[0]) == 2
+        ):  # Check if it's a function with two scalar inputs
             vars = model(z.real.detach().cpu(), z.imag.detach().cpu())
         else:
-            raise ValueError("'model' must be a function with a scalar complex input or 2D real inputs.")
+            raise ValueError(
+                "'model' must be a function with a scalar complex input or 2D real inputs."
+            )
 
     if isinstance(model_true, nn.PIHNN):
         vars_true = model_true(z, real_output=True).detach().cpu()
     else:
-        if len(inspect.getfullargspec(model_true)[0]) == 1: # Check if it's a scalar complex function
+        if (
+            len(inspect.getfullargspec(model_true)[0]) == 1
+        ):  # Check if it's a scalar complex function
             vars_true = model_true(z.detach().cpu())
-        elif len(inspect.getfullargspec(model_true)[0]) == 2: # Check if it's a function with two scalar inputs
+        elif (
+            len(inspect.getfullargspec(model_true)[0]) == 2
+        ):  # Check if it's a function with two scalar inputs
             vars_true = model_true(z.real.detach().cpu(), z.imag.detach().cpu())
         else:
-            raise ValueError("'model_true' must be a function with a scalar complex input or 2D real inputs.")
+            raise ValueError(
+                "'model_true' must be a function with a scalar complex input or 2D real inputs."
+            )
 
-    errors = []    
+    errors = []
     if torch.is_tensor(vars):
-        errors = torch.pow(torch.sum(torch.pow(vars-vars_true,p)),1/p).item() / torch.pow(torch.sum(torch.pow(vars_true,p)),1/p).item()
+        errors = (
+            torch.pow(torch.sum(torch.pow(vars - vars_true, p)), 1 / p).item()
+            / torch.pow(torch.sum(torch.pow(vars_true, p)), 1 / p).item()
+        )
     else:
-        for i in range(min(len(vars),len(vars_true))):
-            errors.append(torch.pow(torch.sum(torch.pow(vars[i]-vars_true[i],p)),1/p).item() / torch.pow(torch.sum(torch.pow(vars_true[i],p)),1/p).item())
+        for i in range(min(len(vars), len(vars_true))):
+            errors.append(
+                torch.pow(torch.sum(torch.pow(vars[i] - vars_true[i], p)), 1 / p).item()
+                / torch.pow(torch.sum(torch.pow(vars_true[i], p)), 1 / p).item()
+            )
     return errors


### PR DESCRIPTION
In the commit a249390f53909708f8750cfe9b752b07ad2fcbe8 the concatenation operation on the string `dir` was removed as it produced an error if `dir` did not end on `/`. Instead `/` is added to the string `dir` simply with the `+` operator

Remark: I was unable to only include the beforementioned commit in the pull request. Hence, commit 334a9ab5676fdc1a2d8c5b64b65509413226f588 is also included. However, this commit does not contain actual changes to the code, just changes related to autopep8 applying its 'beautification' rules.